### PR TITLE
feat: Improve query invalidation and accessibility

### DIFF
--- a/src/components/SuggestWeekModal.tsx
+++ b/src/components/SuggestWeekModal.tsx
@@ -29,7 +29,7 @@ export default function SuggestWeekModal({ open, suggestions, onClose, onConfirm
           {suggestions.map((s) => (
             <label key={s.task.id} className="flex items-start gap-3 p-2">
               <input
-                aria-label={`Select ${s.task.title}`}
+                aria-label={`Include ${s.task.title} in This Week`}
                 type="checkbox"
                 checked={!!checked[s.task.id]}
                 onChange={(e) => setChecked((c) => ({ ...c, [s.task.id]: e.target.checked }))}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -83,7 +83,7 @@ export default function TaskList({ onToast }: { onToast: (msg: string, type?: 's
       setModalOpen(false)
     },
     onError: () => onToast('Failed to move tasks', 'error'),
-    onSettled: () => { qc.invalidateQueries({ queryKey: ['tasks'] }) }
+    onSettled: () => { qc.invalidateQueries({ queryKey: ['tasks'] }); qc.invalidateQueries({ queryKey: ['recs', 'week'] }) }
   })
 
   function splitTags(input: string): string[] {


### PR DESCRIPTION
- After promoting tasks to 'This Week', invalidate both ['tasks'] and ['recs', 'week'] queries to prevent stale data.
- Improve accessibility of the 'Suggested' tray checkboxes by adding a more descriptive aria-label.